### PR TITLE
set config-filename such that verifier can start

### DIFF
--- a/verifier/config.py
+++ b/verifier/config.py
@@ -21,7 +21,7 @@ config_filename = os.environ.get('STACKTACH_VERIFIER_CONFIG',
                                  'stacktach_verifier_config.json')
 try:
     from local_settings import *
-    config_filename = config_filename
+    config_filename = STACKTACH_VERIFIER_CONFIG
 except ImportError:
     pass
 


### PR DESCRIPTION
without manually sourcing config shell script sourcing
